### PR TITLE
Support storing typedefs in unions

### DIFF
--- a/tEndian.h
+++ b/tEndian.h
@@ -98,8 +98,7 @@ protected:
     }
 public:
     // Constructors
-    tLittleEndian() { }
-    tLittleEndian(const tLittleEndian& b) : mData(b.mData) { }
+    tLittleEndian() = default;
 
     //If we endian swap, it happens in two places:
     //1. Set an OE from a PE
@@ -150,8 +149,7 @@ protected:
 
 public:
     // Constructors
-    tBigEndian() { }
-    tBigEndian(const tBigEndian& b) : mData(b.mData) { }
+    tBigEndian() = default;
     
     //If we endian swap, it happens in two places:
     //1. Set an OE from a PE


### PR DESCRIPTION
Currently the typedefs can not be used in unions.
This is because the compiler complains about non-trivial constructors. To fix this we can use the default constructors